### PR TITLE
Simplify root calculation when delta = 0

### DIFF
--- a/bhaskara/bhaskara_2/bhaskara2.go
+++ b/bhaskara/bhaskara_2/bhaskara2.go
@@ -30,7 +30,7 @@ func main() {
 			fmt.Printf("Outch! :-(\n")
 			fmt.Printf("Infelizmente o valor de Delta é negativo. Por favor, reinsira os dados.\n")
 		case d == 0:
-			x1 = (-b + d) / (2 * a)
+			x1 = -b / (2 * a)
 			fmt.Printf("O valor de X é: %v\n", x1)
 		default:
 			x1 = (-b + raizd) / (2 * a)


### PR DESCRIPTION
When delta is 0 (i.e. d == 0), the sum "-b + d" is always equivalent to "-b", so we can make that operation a little more efficient.
--
patch by @cd1 